### PR TITLE
refactor(alloy): switch log scrape from Kubernetes API to hostPath file tailing

### DIFF
--- a/infrastructure/releases/alloy/values.yaml
+++ b/infrastructure/releases/alloy/values.yaml
@@ -42,10 +42,17 @@ alloy:
           separator     = "/"
           target_label  = "job"
         }
+
+        rule {
+          source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+          separator     = "/"
+          target_label  = "__path__"
+          replacement   = "/var/log/pods/*$1/*.log"
+        }
       }
 
-      // Read logs via the Kubernetes API (avoids hostPath permission and glob issues)
-      loki.source.kubernetes "pod_logs" {
+      // Tail pod logs directly from the node filesystem via hostPath mount
+      loki.source.file "pod_logs" {
         targets    = discovery.relabel.pod_logs.output
         forward_to = [loki.process.pod_logs.receiver]
       }
@@ -83,7 +90,7 @@ alloy:
       }
 
   mounts:
-    varlog: false
+    varlog: true
     dockercontainers: false
 
   # Disable anonymous telemetry reporting

--- a/infrastructure/releases/alloy/values.yaml
+++ b/infrastructure/releases/alloy/values.yaml
@@ -117,13 +117,11 @@ controller:
       cpu: 200m
       memory: 256Mi
 
-  securityContext: {}
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
 
-  podSecurityContext:
-    runAsNonRoot: true
-    runAsUser: 473
-    runAsGroup: 473
-    fsGroup: 473
+  podSecurityContext: {}
 
 # RBAC — needed to discover pods via the Kubernetes API
 rbac:


### PR DESCRIPTION
## Summary

- Replaces `loki.source.kubernetes` (Kubernetes API streaming) with `loki.source.file` (hostPath file tailing)
- Enables `mounts.varlog: true` to mount `/var/log` from the host node
- Adds `__path__` relabel rule mapping pod UID + container name to `/var/log/pods/*<uid>/<container>/*.log`
- Sets `runAsUser: 0` on the container securityContext so Alloy can read host log files owned by root

## Why

`loki.source.file` tails log files directly from the node filesystem, giving access to the full on-disk log buffer and remaining functional even when the Kubernetes API is slow or unavailable.

## Notes

Transient `"failed to create source, skipping"` errors are expected on pod startup — Alloy briefly sees targets for pods whose log directories don't yet exist on the current node. These resolve within ~5 seconds on the next discovery evaluation cycle.

Closes #3