### PR TITLE
feat(longhorn): enable Prometheus metrics scraping and Grafana dashboard

### DIFF
--- a/infrastructure/releases/grafana/values.yaml
+++ b/infrastructure/releases/grafana/values.yaml
@@ -105,6 +105,10 @@ dashboards:
       gnetId: 1860
       revision: 37
       datasource: Prometheus
+    longhorn:
+      gnetId: 13032
+      revision: 6
+      datasource: Prometheus
 
 grafana.ini:
   server:

--- a/infrastructure/releases/longhorn/values.yaml
+++ b/infrastructure/releases/longhorn/values.yaml
@@ -1,3 +1,8 @@
+metrics:
+  serviceMonitor:
+    enabled: true
+    interval: 30s
+
 defaultSettings:
   defaultReplicaCount: 1
   storageReservedPercentageForDefaultDisk: 30


### PR DESCRIPTION
## Summary

- Enable Longhorn ServiceMonitor so Prometheus scrapes storage metrics at 30s interval
- Add Longhorn dashboard (gnetId 13032, revision 6) to Grafana

## Changes

- `infrastructure/releases/longhorn/values.yaml` — added `metrics.serviceMonitor.enabled: true` and `interval: 30s`
- `infrastructure/releases/grafana/values.yaml` — added Longhorn dashboard under `dashboards.default`

## Verification

- `ServiceMonitor` `longhorn-prometheus-servicemonitor` confirmed present in `longhorn-system`
- Grafana pod restarted cleanly with dashboard wired in

Closes #6