### PR TITLE
feat(scheduling): constrain Grafana and ingress-nginx to specific worker nodes

### DIFF
--- a/infrastructure/releases/grafana/values.yaml
+++ b/infrastructure/releases/grafana/values.yaml
@@ -1,5 +1,15 @@
 replicas: 1
 
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node-role/worker
+              operator: In
+              values:
+                - "true"
+
 deploymentStrategy:
   type: Recreate
 

--- a/infrastructure/releases/ingress-nginx/values.yaml
+++ b/infrastructure/releases/ingress-nginx/values.yaml
@@ -1,6 +1,15 @@
 controller:
   # -- Setting replica count to 2 for high availability
   replicaCount: 2
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node-role/worker
+                operator: In
+                values:
+                  - "true"
   ingressClassResource:
     # -- Name of the ingressClass
     name: nginx-internal

--- a/talos/patches/worker-01.yaml
+++ b/talos/patches/worker-01.yaml
@@ -6,6 +6,8 @@ machine:
     image: factory.talos.dev/metal-installer/613e1592b2da41ae5e265e8789429f22e121aab91cb4deb6bc3c0b6262961245:v1.12.6
   network:
     hostname: talos-worker-01
+  nodeLabels:
+    node-role/worker: "true"
   # Data Path Mounts
   # Provide additional data path mounts accessible to the Kubernetes Kubelet container.
   # These mounts are necessary to provide access to the host directories,

--- a/talos/patches/worker-02.yaml
+++ b/talos/patches/worker-02.yaml
@@ -6,6 +6,8 @@ machine:
     image: factory.talos.dev/metal-installer/613e1592b2da41ae5e265e8789429f22e121aab91cb4deb6bc3c0b6262961245:v1.12.6
   network:
     hostname: talos-worker-02
+  nodeLabels:
+    node-role/worker: "true"
   # Data Path Mounts
   # Provide additional data path mounts accessible to the Kubernetes Kubelet container.
   # These mounts are necessary to provide access to the host directories,


### PR DESCRIPTION
## Summary

- Add `node-role/worker=true` label to worker node Talos machine config patches
- Add `nodeAffinity` to Grafana and ingress-nginx to schedule exclusively on labeled worker nodes

## Changes

- `talos/patches/worker-01.yaml` — add `nodeLabels: node-role/worker: "true"`
- `talos/patches/worker-02.yaml` — add `nodeLabels: node-role/worker: "true"`
- `infrastructure/releases/grafana/values.yaml` — add `nodeAffinity` (requiredDuringScheduling)
- `infrastructure/releases/ingress-nginx/values.yaml` — add `nodeAffinity` under `controller`

## Verification

- `node-role/worker=true` label confirmed present on `talos-worker-01`
- Grafana pod running on `talos-worker-02`
- ingress-nginx pods running on `talos-worker-01` and `talos-worker-02`
- No active pods on `talos-cp-01`

Closes #8