### PR TITLE
fix(alloy): expand pod_logs glob via local.file_match before tailing

### DIFF
--- a/infrastructure/releases/alloy/values.yaml
+++ b/infrastructure/releases/alloy/values.yaml
@@ -51,9 +51,14 @@ alloy:
         }
       }
 
+      // Expand the glob in __path__ into concrete files (loki.source.file does not glob)
+      local.file_match "pod_logs" {
+        path_targets = discovery.relabel.pod_logs.output
+      }
+
       // Tail pod logs directly from the node filesystem via hostPath mount
       loki.source.file "pod_logs" {
-        targets    = discovery.relabel.pod_logs.output
+        targets    = local.file_match.pod_logs.targets
         forward_to = [loki.process.pod_logs.receiver]
       }
 


### PR DESCRIPTION
loki.source.file does not glob __path__ patterns, so passing discovery.relabel.pod_logs.output directly caused stat failures on the unexpanded glob paths. Insert a local.file_match step to resolve the glob into concrete files before forwarding to loki.source.file.

Refs #14