### PR TITLE
fix(prometheus): cap TSDB at 7d / 8GB to prevent PVC exhaustion

### DIFF
--- a/infrastructure/releases/prometheus/values.yaml
+++ b/infrastructure/releases/prometheus/values.yaml
@@ -49,7 +49,8 @@ prometheus:
     podMonitorSelector: {}
     podMonitorNamespaceSelector: {}
 
-    retention: 15d
+    retention: 7d
+    retentionSize: 8GB
     walCompression: true
 
     # Non-root security context (mirrors the old prometheus chart config)


### PR DESCRIPTION
## Summary
- Sets `retention: 7d` (was `15d`) and adds `retentionSize: 8GB` to the kube-prometheus-stack values, giving Prometheus a hard ceiling below the 10Gi PVC capacity so blocks are dropped before the disk fills.
- Fixes the root cause of the 2026-05-20 incident where the PVC hit 100%, corrupted the WAL, and blinded all scrape targets and alerting rules for 4h 47m.

Closes #15.

## Test plan
- [x] `helmfile diff` shows only the two retention lines changing
- [x] `helmfile apply` succeeds; statefulset rolls cleanly (1 pod, 2/2 Running)
- [x] Prometheus runtime flags confirmed via `/proc/1/cmdline`: `--storage.tsdb.retention.time=7d` and `--storage.tsdb.retention.size=8GB`
- [x] Pod log shows `"TSDB retention updated" duration=1w size=8GiB`
- [x] PVC usage dropped 80% → 59% as older blocks were dropped to honor the 8GB cap
- [x] No `no space left on device` errors in fresh logs
- [x] Re-verify `KubePersistentVolumeFillingUp` alert rule is loaded in the operator (currently not firing — disk is healthy)