### PR TITLE
fix(loki): enable compactor retention to enforce 7-day log expiry

### DIFF
--- a/infrastructure/releases/loki/values.yaml
+++ b/infrastructure/releases/loki/values.yaml
@@ -23,6 +23,10 @@ loki:
   limits_config:
     retention_period: 168h  # 7 days
 
+  compactor:
+    retention_enabled: true
+    delete_request_store: s3
+
   schemaConfig:
     configs:
       - from: "2024-01-01"


### PR DESCRIPTION
## Summary

- `retention_period: 168h` was configured in `limits_config` but silently ignored because `retention_enabled: true` was missing from the compactor config
- Adds `retention_enabled: true` and `delete_request_store: s3` (required for TSDB schema) so the compactor enforces the 7-day retention window
- Without this fix, MinIO PVC (`pvc-28388f6f-7205-44a7-96e2-4fa55d36cfd9`, 20 Gi) grows unbounded at ~36 MB/day

## Test plan

- [ ] Compactor logs show retention/deletion activity after first compaction cycle (~10 min after deploy)
- [ ] MinIO `export-0` usage drops from ~540 MB (14 days) toward ~280 MB (7 days)
- [ ] PVC usage stays bounded over subsequent days

Closes #18