### PR TITLE
fix(grafana): restore Loki dashboards with correct datasource and UID

### DIFF
--- a/infrastructure/releases/grafana/values.yaml
+++ b/infrastructure/releases/grafana/values.yaml
@@ -57,6 +57,7 @@ datasources:
     datasources:
       - name: Prometheus
         type: prometheus
+        uid: PBFA97CFB590B2093
         url: http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090
         access: proxy
         isDefault: true
@@ -95,17 +96,9 @@ dashboardProviders:
 
 dashboards:
   default:
-    loki-logs:
-      gnetId: 13407
-      revision: 1
-      datasource: Loki
     nginx-ingress:
       gnetId: 9614
       revision: 1
-      datasource: Prometheus
-    loki-stack-monitoring:
-      gnetId: 14055
-      revision: 5
       datasource: Prometheus
     loki-app-logs:
       gnetId: 13639

--- a/infrastructure/releases/loki/values.yaml
+++ b/infrastructure/releases/loki/values.yaml
@@ -38,6 +38,11 @@ loki:
           period: 24h
 
 monitoring:
+  dashboards:
+    enabled: true
+    namespace: monitoring
+    labels:
+      grafana_dashboard: "1"
   serviceMonitor:
     enabled: true
     interval: 30s


### PR DESCRIPTION
## Summary

- Add `uid: PBFA97CFB590B2093` to Prometheus datasource — without a fixed UID, Grafana assigns a random one on each redeploy, breaking all community dashboards that hardcode this UID
- Remove `loki-logs` (gnetId 13407) — Loki 2.x era dashboard; Grafana's download script patched all datasources to `Loki`, sending 44 PromQL panels to the Loki backend (which returns HTTP 400 for PromQL)
- Remove `loki-stack-monitoring` (gnetId 14055) — uses stale `cortex_*` metric names and Promtail label selectors, both incompatible with Loki 3.6.7 and Alloy
- Enable `monitoring.dashboards` in Loki chart to provision 10 official Loki 3.x dashboards as ConfigMaps picked up by the Grafana sidecar

## Dashboards now provisioned

| Dashboard | Coverage |
|-----------|----------|
| loki-reads.json | Query path (frontend, querier, scheduler) |
| loki-writes.json | Ingest path (distributor, ingester) |
| loki-operational.json | Overall cluster health |
| loki-chunks.json | Chunk cache metrics |
| loki-retention.json | Compactor retention activity |
| loki-deletion.json | Delete request tracking |
| loki-reads-resources.json | CPU/memory for read path |
| loki-writes-resources.json | CPU/memory for write path |
| loki-logs.json | Log-based metrics |
| loki-mixin-recording-rules.json | Supporting rules |

## Test plan

- [ ] Grafana sidecar loaded 10 Loki dashboard ConfigMaps (`kubectl get configmap -n monitoring -l grafana_dashboard=1 | grep loki`)
- [ ] All 10 dashboards visible in Grafana under default folder
- [ ] Panels show data (job labels `monitoring/loki-*` match dashboard queries)
- [ ] Prometheus datasource UID persists across Grafana pod restarts

Closes #20