### PR TITLE
feat(metrics-server): deploy metrics-server for kubectl top / metrics API

### DIFF
--- a/infrastructure/helmfile.yaml
+++ b/infrastructure/helmfile.yaml
@@ -13,3 +13,4 @@ helmfiles:
   - path: releases/pihole/helmfile.yaml # pihole
   - path: releases/external-dns/helmfile.yaml # external-dns
   - path: releases/longhorn/helmfile.yaml # longhorn distribute storage
+  - path: releases/metrics-server/helmfile.yaml # metrics-server: backs the metrics.k8s.io API (kubectl top / HPA)

--- a/infrastructure/releases/metrics-server/helmfile.yaml
+++ b/infrastructure/releases/metrics-server/helmfile.yaml
@@ -1,0 +1,11 @@
+repositories:
+  - name: metrics-server
+    url: https://kubernetes-sigs.github.io/metrics-server/
+
+releases:
+  - name: metrics-server
+    namespace: kube-system
+    chart: metrics-server/metrics-server
+    version: 3.13.0
+    values:
+      - values.yaml

--- a/infrastructure/releases/metrics-server/values.yaml
+++ b/infrastructure/releases/metrics-server/values.yaml
@@ -1,0 +1,14 @@
+# On Talos Linux the kubelet serving cert is self-signed and not trusted by
+# metrics-server's CA bundle. --kubelet-insecure-tls skips cert verification
+# for the kubelet scrape. Traffic stays in-cluster so this is acceptable for
+# a homelab environment.
+args:
+  - --kubelet-insecure-tls
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi


### PR DESCRIPTION
## Summary

Deploys `metrics-server` so the `metrics.k8s.io` aggregated API is available — `kubectl top` (and HPAs) now work. Previously `kubectl top node` failed with `error: Metrics API not available` because no metrics-server existed in the cluster.

## Changes

- New release `infrastructure/releases/metrics-server/` (chart `metrics-server/metrics-server` 3.13.0, app v0.8.0), namespace `kube-system`.
- `values.yaml`: `--kubelet-insecure-tls` — on Talos the kubelet serving cert is self-signed and not trusted by metrics-server's CA bundle; the scrape stays in-cluster, acceptable for the homelab. Resource requests/limits 50m/64Mi → 100m/128Mi.
- Wired into the root `infrastructure/helmfile.yaml` `helmfiles:` list.

## Verification (live cluster)

```
$ kubectl get apiservices v1beta1.metrics.k8s.io
NAME                     SERVICE                      AVAILABLE   AGE
v1beta1.metrics.k8s.io   kube-system/metrics-server   True        2m32s

$ kubectl top node
NAME              CPU(cores)   CPU(%)   MEMORY(bytes)   MEMORY(%)
talos-cp-01       2101m        53%      6346Mi          41%
talos-worker-01   428m         3%       1911Mi          26%
talos-worker-02   296m         2%       1671Mi          23%

$ kubectl top pod -A    # returns data across all namespaces
```

All acceptance criteria from #24 pass.

Closes #24