### PR TITLE
fix(talos): disable scheduling on control-plane to relieve cp-01 CPU

### DIFF
--- a/talos/patches/cp-01.yaml
+++ b/talos/patches/cp-01.yaml
@@ -1,5 +1,8 @@
 cluster:
-  allowSchedulingOnControlPlanes: true
+  # Keep heavy workloads off the control-plane node (4 cores vs workers' 12).
+  # false re-applies the node-role.kubernetes.io/control-plane:NoSchedule taint;
+  # admit specific infra pods back with a matching toleration if needed. See #28.
+  allowSchedulingOnControlPlanes: false
   apiServer:
     admissionControl:
       - name: PodSecurity


### PR DESCRIPTION
## Summary
Closes #28 (partial — the repo-committable part).

`talos-cp-01` (4 cores) was running ~50% CPU while the 12-core workers sat at 9% / 2%. This sets `allowSchedulingOnControlPlanes: false` so Talos re-applies the `node-role.kubernetes.io/control-plane:NoSchedule` taint. Heavy app workloads (e.g. langfuse-clickhouse, Prometheus) drain to the workers; control-plane components keep running via their built-in toleration.

## Change
- `talos/patches/cp-01.yaml`: `allowSchedulingOnControlPlanes: true` → `false`, with an explanatory comment.

## Apply (after merge)
```bash
export TALOSCONFIG="talos/configs/talosconfig"
talosctl apply-config --nodes 192.168.1.50 \
  --file talos/configs/controlplane.yaml \
  --config-patch @talos/patches/controlplane.yaml \
  --config-patch @talos/patches/cp-01.yaml
```

## Follow-up (live cluster ops, not in this PR)
- Drain Longhorn replicas off cp-01 (8 of 13): set `replica-auto-balance: best-effort` and/or disable scheduling + request eviction in the Longhorn UI.
- Reconsider `default-replica-count: 1` (no storage redundancy).