### PR TITLE
fix(longhorn): raise storageOverProvisioningPercentage to 100 to unblock cp-01 replica eviction

### DIFF
--- a/infrastructure/releases/longhorn/values.yaml
+++ b/infrastructure/releases/longhorn/values.yaml
@@ -6,6 +6,12 @@ metrics:
 defaultSettings:
   defaultReplicaCount: 1
   storageReservedPercentageForDefaultDisk: 30
+  # Thin-provisioning headroom. Longhorn schedules by a volume's *requested*
+  # size, not actual usage; the default 100 lets total requested replica size
+  # equal a disk's schedulable capacity. The previous value of 30 throttled
+  # scheduling to a third of the disk and caused "insufficient storage" on the
+  # workers during cp-01 replica eviction. See #28.
+  storageOverProvisioningPercentage: 100
 
 persistence:
   defaultClassReplicaCount: 1


### PR DESCRIPTION
## Summary

Restores Longhorn's `storageOverProvisioningPercentage` to the default **100** (it had drifted to **30** on the live cluster, unset in Git). The low cap was throttling each worker disk to ~1/3 of its schedulable base and caused `Replica Scheduling Failure — insufficient storage` while draining replicas off the control-plane node.

Fixes #30. Part of the #28 effort (cp-01 CPU saturation + Longhorn replica skew).

## Why

Longhorn schedules by a volume's *requested* size, not actual usage. With over-provisioning at 30%:

| Node | Schedulable base | OP cap @30% | Scheduled | Room |
|------|------------------|-------------|-----------|------|
| worker-01 | 165Gi | 49.6Gi | 40Gi | 9.6Gi |
| worker-02 | 165Gi | 49.6Gi | 41Gi | 8.6Gi |

~18Gi combined headroom vs ~50Gi of replicas to drain → scheduling failed despite hundreds of GB of free disk. The physical guards (`storageReservedPercentageForDefaultDisk: 30`, `storageMinimalAvailablePercentage: 25`) remain in place, so real disk-full is still prevented.

## Changes

- `infrastructure/releases/longhorn/values.yaml`: add `storageOverProvisioningPercentage: 100` to `defaultSettings`.

Also included on the branch (context for #28):
- `talos/patches/cp-01.yaml`: `allowSchedulingOnControlPlanes: false` — re-applies the control-plane `NoSchedule` taint to drain heavy workloads to the workers.

## Validation

- Applied via `helmfile -l name=longhorn apply`; live `storage-over-provisioning-percentage` setting now `100`.
- Worker headroom restored (~125Gi / ~104Gi).
- All 8 cp-01 replicas drained to workers; 11 volumes report `healthy`.
- cp-01 CPU: ~50% → 13%.

## Follow-ups (not in this PR)

- Make cp-01's storage-node exclusion fully GitOps (label-gated disks via `createDefaultDiskLabeledNodes` + Talos node labels).
- Clean up the phantom/broken disk entry on worker-02 (`0Gi` total / `-100Gi` schedulable).