### PR TITLE
chore(security): add gitleaks pre-commit hook for secret scanning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
## Summary

Add a [pre-commit](https://pre-commit.com/) hook running [gitleaks](https://github.com/gitleaks/gitleaks) (pinned `v8.30.0`) to block commits containing hardcoded secrets before they reach git history.

## Motivation

This repo manages cluster secrets (SOPS-encrypted `talos/secrets.yaml`, `loki/resources/secret.yaml`). A local secret-scanning gate catches accidental plaintext credentials at commit time.

## Changes

- Add `.pre-commit-config.yaml` with the `gitleaks` hook pinned to `rev: v8.30.0`.

## Setup / verification

```bash
uv tool install pre-commit   # framework (brew failed on a Nix-patched bottle bug)
pre-commit install           # wires .git/hooks/pre-commit
pre-commit run gitleaks --all-files   # passed, no secrets detected
```

gitleaks now runs automatically on every `git commit`, scanning staged changes.

## Follow-ups (optional)

- [ ] Switch to a `local`/system-binary hook to avoid building gitleaks from source in fresh environments.
- [ ] Add a `gitleaks` step to CI so the gate is enforced beyond local machines.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)