### PR TITLE
fix(grafana): move admin credentials out of tracked values.yaml

### DIFF
--- a/infrastructure/releases/grafana/helmfile.yaml
+++ b/infrastructure/releases/grafana/helmfile.yaml
@@ -9,3 +9,5 @@ releases:
     version: 10.5.15
     values:
       - values.yaml
+      # secrets file is gitignored — admin credentials in resources/secret.yaml
+      - resources/secret.yaml

--- a/infrastructure/releases/grafana/values.yaml
+++ b/infrastructure/releases/grafana/values.yaml
@@ -129,6 +129,5 @@ serviceMonitor:
   labels:
     release: prometheus
 
-# Admin credentials — override the default "admin/admin"
-adminUser: admin
-adminPassword: ***REMOVED***
+# Admin credentials are supplied via the gitignored resources/secret.yaml
+# (merged as an extra Helm values file in helmfile.yaml). Never commit them here.


### PR DESCRIPTION
Closes #26

## Problem
Grafana admin credentials were stored in plaintext in the Git-tracked `infrastructure/releases/grafana/values.yaml`.

## Change
- Remove `adminUser`/`adminPassword` from the tracked `values.yaml`, replaced with a pointer comment.
- Source credentials from `resources/secret.yaml`, which is gitignored (`infrastructure/releases/*/resources/secret.yaml`) and merged as an extra Helm values file in `helmfile.yaml` — matching the existing `langfuse` release pattern.

## Follow-up (operational, outside this PR)
- The previously committed password was exposed in Git history; that history has been scrubbed and force-pushed. **The live Grafana admin password must be rotated** — set a strong value in the gitignored `resources/secret.yaml`, then:
  ```bash
  kubectl -n monitoring exec deploy/grafana -- grafana-cli admin reset-admin-password '<new-password>'
  ```

## Notes
- The gitleaks pre-commit hook passes — no secrets in tracked files.