### PR TITLE
fix(loki): right-size memcached caches to fit worker node memory

### DIFF
--- a/apps/observability/releases/loki/values.yaml
+++ b/apps/observability/releases/loki/values.yaml
@@ -148,6 +148,15 @@ compactor:
     storageClass: longhorn
     size: 10Gi
 
+# Right-size the memcached caches so they fit a 7 GiB worker node.
+# The chart default chunksCache.allocatedMemory is 8192 MB, which yields a
+# memcached request of ~9.6 GiB (allocatedMemory * 1.2) and can never schedule.
+chunksCache:
+  allocatedMemory: 2048  # MB; memcached request ≈ 2.4 GiB
+
+resultsCache:
+  allocatedMemory: 1024  # MB; memcached request ≈ 1.2 GiB
+
 # Enable bundled MinIO as S3-compatible object store
 minio:
   enabled: true


### PR DESCRIPTION
The chunks-cache default chunksCache.allocatedMemory (8192 MB) yields a
memcached request of ~9.6Gi (allocatedMemory * 1.2), exceeding the ~7 GiB
allocatable on either worker, so loki-chunks-cache-0 was stuck Pending and
never scheduled.

- Set chunksCache.allocatedMemory to 2048 MB (request ~2.4Gi)
- Set resultsCache.allocatedMemory to 1024 MB (request ~1.2Gi)

Closes #42
