### PR TITLE
feat(longhorn): add tiered ssd/hdd storage backed by /dev/sda data disk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,8 @@ k8s-homelab/
 │   ├── configs/            # Generated machine configs (gitignored)
 │   └── patches/            # Node-specific overlays applied at bootstrap
 │       ├── cp-01.yaml          # Hostname, CNI=none + kube-proxy disabled (Cilium), PodSecurity exemptions, AllowSchedulingOnCP, Longhorn mounts
-│       └── worker-0{1,2}.yaml  # Per-worker hostname + storage mounts
+│       ├── worker-0{1,2}.yaml  # Per-worker hostname + storage mounts
+│       └── worker-data-disk.yaml # UserVolumeConfig: spare SATA disk → /var/mnt/hdd (Longhorn HDD tier; both workers)
 ├── infrastructure/         # Core cluster infrastructure Helm releases managed by Helmfile
 │   ├── helmfile.yaml        # Root helmfile (includes only core infra releases)
 │   └── releases/            # One sub-helmfile per release
@@ -26,7 +27,7 @@ k8s-homelab/
 │       ├── ingress-nginx/   # Internal ingress controller (namespace: infra)
 │       ├── pihole/          # DNS + ad-block at 192.168.1.250 (namespace: infra)
 │       ├── external-dns/    # Syncs Ingress hostnames → Pi-hole DNS
-│       ├── longhorn/        # Distributed block storage (namespace: longhorn-system)
+│       ├── longhorn/        # Distributed block storage (namespace: longhorn-system); tiered ssd/hdd disks
 │       └── metrics-server/  # Backs metrics.k8s.io API (kubectl top / HPA)
 └── apps/                   # Application-layer Helm releases (run on top of the cluster)
     └── observability/       # Observability stack (namespace: monitoring)
@@ -105,7 +106,9 @@ talosctl gen config homelab https://$CONTROL_PLANE_IP:6443 \
 
 **PodSecurity exemptions:** the `infra` namespace is exempted from PodSecurity admission in `talos/patches/cp-01.yaml`. Cilium runs in `kube-system`, which is exempt cluster-wide. Add new privileged namespaces there.
 
-**Longhorn storage mounts:** Worker nodes and the control-plane require the kubelet `extraMounts` for `/var/lib/longhorn` defined in each node patch file. Any new worker node patch must include these mounts.
+**Longhorn storage mounts:** Worker nodes and the control-plane require the kubelet `extraMounts` for `/var/lib/longhorn` defined in each node patch file. Any new worker node patch must include these mounts. Workers additionally bind-mount `/var/mnt/hdd` (the spare SATA disk provisioned by `talos/patches/worker-data-disk.yaml`).
+
+**Longhorn storage tiers:** Two tagged disk tiers (see #9). The fast NVMe disk `/var/lib/longhorn` is tagged `ssd`; the default `longhorn` StorageClass pins to it (`persistence.defaultDiskSelector: ssd` in `values.yaml`), so general PVCs stay on fast storage. The HDD `/var/mnt/hdd` (workers only) is tagged `hdd` and exposed via the opt-in `longhorn-hdd` StorageClass (`resources/storageclass-hdd.yaml`) — set `storageClassName: longhorn-hdd` to land a PVC there. Disk tagging + HDD registration are applied declaratively by the `releases/longhorn/resources/disks.sh` **postsync hook** (patches `nodes.longhorn.io`, matching the NVMe disk by path so it's not tied to the generated disk key; requires `jq`). Longhorn tags are one-directional, so both tiers are tagged — tagging only the HDD would not keep default volumes off it. `defaultDiskSelector` requires the Longhorn chart **≥ 1.7** (1.6.x ignores it) — the release is pinned to 1.7.2. StorageClass parameters are immutable, but the 1.6→1.7 bump recreated the default class so it picked up the selector automatically; changing the selector later without a chart change needs a one-time `kubectl delete storageclass longhorn`.
 
 **Monitoring stack architecture:** `kube-prometheus-stack` is deployed with its bundled Grafana and Alertmanager **disabled** — standalone `grafana` and a separate Alertmanager release are used instead. The bundled stack's `forceDeployDashboards: true` pushes dashboard ConfigMaps that the standalone Grafana sidecar picks up via `grafana_dashboard: "1"` labels.
 

--- a/infrastructure/releases/longhorn/README.md
+++ b/infrastructure/releases/longhorn/README.md
@@ -1,0 +1,62 @@
+# Longhorn — distributed block storage (tiered)
+
+Longhorn provides the cluster's block storage. Disks are split into two tagged
+tiers so fast and bulk storage are addressable independently (issue #9).
+
+## Storage tiers
+
+| Tier | Disk | Path | Tag | StorageClass |
+| ---- | ---- | ---- | --- | ------------ |
+| Fast (default) | NVMe | `/var/lib/longhorn` | `ssd` | `longhorn` (default) |
+| Bulk (opt-in)  | SATA HDD (workers) | `/var/mnt/hdd` | `hdd` | `longhorn-hdd` |
+
+PVCs default to the fast tier. To place a volume on the HDD, set
+`storageClassName: longhorn-hdd`:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: bulk-data
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: longhorn-hdd
+  resources:
+    requests:
+      storage: 100Gi
+```
+
+## How the tiers are wired
+
+- **HDD provisioning (Talos):** `talos/patches/worker-data-disk.yaml` is a
+  `UserVolumeConfig` that formats the spare SATA disk (`xfs`) and auto-mounts it
+  at `/var/mnt/hdd` on both workers. The worker patches bind-mount that path into
+  the kubelet so Longhorn can use it.
+- **Disk tagging + registration (`resources/disks.sh`, postsync hook):** tags every node's
+  `/var/lib/longhorn` disk `ssd` (matched by path), and registers `/var/mnt/hdd`
+  as the `hdd` disk on worker nodes. Idempotent `nodes.longhorn.io` merge-patches.
+  Requires `kubectl` + `jq` on the machine running `helmfile apply`.
+- **Default class → ssd (`values.yaml`):** `persistence.defaultDiskSelector`
+  pins the default `longhorn` class to the `ssd` tier. Longhorn disk tags are
+  one-directional (a tag only constrains volumes that *request* it), so both
+  tiers are tagged — tagging only the HDD would not keep default volumes off it.
+- **`longhorn-hdd` class (`resources/storageclass-hdd.yaml`):** applied by a
+  postsync hook for opt-in bulk volumes (`diskSelector: hdd`).
+
+## Chart version & the immutable-StorageClass caveat
+
+`persistence.defaultDiskSelector` only exists in the Longhorn chart from **1.7**
+onward — 1.6.x silently ignores it. This release is pinned to **1.7.2**.
+
+StorageClass parameters are **immutable**, but the 1.6→1.7 chart bump recreated
+the default class, so it picked up `diskSelector: ssd` automatically — no manual
+step was needed. If you ever change the selector *without* a chart change, the
+existing class must be recreated once:
+
+```bash
+kubectl delete storageclass longhorn   # Longhorn recreates it from the updated ConfigMap
+```
+
+Safe — PVs reference the provisioner (`driver.longhorn.io`), not the class, and
+existing volumes already live on the NVMe disk, so nothing reschedules.
+Tags/selectors only affect **newly** provisioned volumes.

--- a/infrastructure/releases/longhorn/helmfile.yaml
+++ b/infrastructure/releases/longhorn/helmfile.yaml
@@ -6,7 +6,9 @@ releases:
   - name: longhorn
     namespace: longhorn-system
     chart: longhorn/longhorn
-    version: 1.6.2
+    # 1.7.x is the first chart line that wires persistence.defaultDiskSelector
+    # into the default StorageClass (needed for the ssd/hdd tiering). See #9.
+    version: 1.7.2
     values:
       - values.yaml
     hooks:
@@ -16,4 +18,19 @@ releases:
           - apply
           - -f
           - '{{ requiredEnv "PWD" }}/releases/longhorn/resources/namespace.yaml'
+        showlogs: true
+      # Register the storage tiers once the Longhorn CRDs/node CRs exist: tag the
+      # NVMe disk "ssd" and add the HDD disk (/var/mnt/hdd) on workers. See #9.
+      - events: ["postsync"]
+        command: bash
+        args:
+          - '{{ requiredEnv "PWD" }}/releases/longhorn/resources/disks.sh'
+        showlogs: true
+      # Opt-in StorageClass for the bulk HDD tier (diskSelector: hdd).
+      - events: ["postsync"]
+        command: kubectl
+        args:
+          - apply
+          - -f
+          - '{{ requiredEnv "PWD" }}/releases/longhorn/resources/storageclass-hdd.yaml'
         showlogs: true

--- a/infrastructure/releases/longhorn/resources/disks.sh
+++ b/infrastructure/releases/longhorn/resources/disks.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Registers Longhorn's two storage tiers (issue #9). Run as a helmfile postsync
+# hook, mirroring releases/cilium/config.sh.
+#
+#   - Fast tier (ssd): the NVMe disk at /var/lib/longhorn on every Longhorn node
+#     is tagged "ssd". The default StorageClass (diskSelector: ssd, set in
+#     values.yaml) pins to it, keeping general workloads on fast storage.
+#   - Bulk tier (hdd): the SATA disk mounted at /var/mnt/hdd (provisioned by
+#     talos/patches/worker-data-disk.yaml) is registered as a second disk on
+#     each worker node and tagged "hdd" for the opt-in longhorn-hdd StorageClass.
+#
+# Tagging is one-directional in Longhorn (a tag only constrains volumes that
+# request it), so both tiers must be tagged to keep default volumes off the HDD.
+#
+# All changes are idempotent JSON merge-patches against nodes.longhorn.io. The
+# NVMe disk is matched by path, not its generated disk key, so it is not fragile.
+# Requires: kubectl, jq.
+
+set -euo pipefail
+
+NAMESPACE="longhorn-system"
+SSD_PATH="/var/lib/longhorn"
+HDD_PATH="/var/mnt/hdd"
+
+function require_tools() {
+    for tool in kubectl jq; do
+        command -v "$tool" >/dev/null 2>&1 || {
+            echo "ERROR: '$tool' is required but not installed." >&2
+            exit 1
+        }
+    done
+}
+
+function wait_for_crd() {
+    until kubectl get crd nodes.longhorn.io &>/dev/null; do
+        echo "Waiting for CRD nodes.longhorn.io to be available..."
+        sleep 10
+    done
+}
+
+# Block until the node's default disk (SSD_PATH) is registered so it can be
+# looked up by path. Longhorn registers it shortly after the node CR appears.
+# Longhorn stores the default path with a trailing slash (/var/lib/longhorn/),
+# so paths are compared with the trailing slash stripped.
+function wait_for_default_disk() {
+    local node="$1"
+    until kubectl -n "$NAMESPACE" get nodes.longhorn.io "$node" -o json 2>/dev/null \
+        | jq -e --arg p "$SSD_PATH" \
+            '(.spec.disks // {}) | to_entries[] | select((.value.path | rtrimstr("/")) == $p)' \
+            >/dev/null; do
+        echo "Waiting for node '$node' to register its default disk ($SSD_PATH)..."
+        sleep 10
+    done
+}
+
+# Tag the disk whose path == SSD_PATH with ["ssd"] (looked up by path).
+function tag_ssd_disk() {
+    local node="$1"
+    local key
+    key=$(kubectl -n "$NAMESPACE" get nodes.longhorn.io "$node" -o json \
+        | jq -r --arg p "$SSD_PATH" \
+            '.spec.disks | to_entries[] | select((.value.path | rtrimstr("/")) == $p) | .key')
+
+    echo "Tagging $SSD_PATH on '$node' (disk key: $key) -> ssd"
+    kubectl -n "$NAMESPACE" patch nodes.longhorn.io "$node" --type=merge \
+        -p "$(jq -n --arg k "$key" '{spec:{disks:{($k):{tags:["ssd"]}}}}')"
+}
+
+# Register the HDD disk at HDD_PATH (idempotent merge — adds/updates the "hdd"
+# disk without disturbing the existing default disk).
+function add_hdd_disk() {
+    local node="$1"
+    echo "Registering $HDD_PATH on '$node' -> hdd"
+    kubectl -n "$NAMESPACE" patch nodes.longhorn.io "$node" --type=merge -p '{
+      "spec": {
+        "disks": {
+          "hdd": {
+            "path": "/var/mnt/hdd",
+            "diskType": "filesystem",
+            "allowScheduling": true,
+            "evictionRequested": false,
+            "storageReserved": 0,
+            "tags": ["hdd"]
+          }
+        }
+      }
+    }'
+}
+
+function main() {
+    require_tools
+    wait_for_crd
+
+    # Fast tier: tag /var/lib/longhorn "ssd" on every Longhorn node.
+    for node in $(kubectl -n "$NAMESPACE" get nodes.longhorn.io \
+        -o jsonpath='{.items[*].metadata.name}'); do
+        wait_for_default_disk "$node"
+        tag_ssd_disk "$node"
+    done
+
+    # Bulk tier: register /var/mnt/hdd on worker nodes only — they carry the
+    # spare SATA disk; the control plane does not.
+    for node in $(kubectl get nodes -l node-role/worker=true \
+        -o jsonpath='{.items[*].metadata.name}'); do
+        add_hdd_disk "$node"
+    done
+}
+
+main "$@"

--- a/infrastructure/releases/longhorn/resources/storageclass-hdd.yaml
+++ b/infrastructure/releases/longhorn/resources/storageclass-hdd.yaml
@@ -1,0 +1,17 @@
+# Opt-in bulk-storage StorageClass for the HDD tier (issue #9). PVCs that set
+# storageClassName: longhorn-hdd land on disks tagged "hdd" (/var/mnt/hdd on the
+# worker nodes). The default `longhorn` class stays pinned to the fast NVMe tier.
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: longhorn-hdd
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "1"
+  staleReplicaTimeout: "30"
+  fromBackup: ""
+  diskSelector: "hdd"
+  dataLocality: "disabled"

--- a/infrastructure/releases/longhorn/values.yaml
+++ b/infrastructure/releases/longhorn/values.yaml
@@ -15,6 +15,22 @@ defaultSettings:
 
 persistence:
   defaultClassReplicaCount: 1
+  # Pin the default `longhorn` StorageClass to the fast NVMe tier (disks tagged
+  # "ssd" by releases/longhorn/resources/disks.sh) so general PVCs never land on the slow
+  # HDD. Longhorn disk tags only constrain volumes that request them, so the
+  # default class must be steered explicitly. Opt into the HDD tier with the
+  # separate `longhorn-hdd` class. Requires chart >= 1.7 (1.6.x ignores this
+  # key). See #9.
+  #
+  # NOTE: StorageClass parameters are immutable. The 1.6->1.7 chart bump
+  # recreated the default class, so it picked up the selector automatically. If
+  # you later change the selector *without* a chart change, delete the class once
+  # so Longhorn recreates it:  kubectl delete storageclass longhorn
+  # Safe — PVs reference the provisioner, not the class, and current volumes live
+  # on NVMe, so nothing reschedules.
+  defaultDiskSelector:
+    enable: true
+    selector: "ssd"
 
 longhornUI:
   replicas: 1

--- a/talos/README.md
+++ b/talos/README.md
@@ -7,7 +7,8 @@ talos/
 ├── patches/
 │   ├── cp-01.yaml             # Control plane: hostname, CNI=none + proxy disabled (Cilium), PodSecurity, Longhorn mounts
 │   ├── worker-01.yaml         # Worker hostname + Longhorn mounts
-│   └── worker-02.yaml
+│   ├── worker-02.yaml
+│   └── worker-data-disk.yaml  # UserVolumeConfig: spare SATA disk -> /var/mnt/hdd (Longhorn HDD tier, both workers)
 └── secrets.yaml               # encrypted with SOPS/age
 ```
 
@@ -85,17 +86,21 @@ After setting up your control plane, use the following steps to add worker nodes
 export WORKER_IP1=192.168.1.54
 export WORKER_IP2=192.168.1.55
 
-# Apply the worker configuration
+# Apply the worker configuration. worker-data-disk.yaml provisions the spare
+# SATA disk as the Longhorn HDD tier (/var/mnt/hdd) and is shared by both
+# workers — it wipes + reformats the selected disk on first apply.
 talosctl apply-config \
     --nodes $WORKER_IP1 \
     --file configs/worker.yaml \
     --config-patch @patches/worker-01.yaml \
+    --config-patch @patches/worker-data-disk.yaml \
     --insecure 
 
 talosctl apply-config \
     --nodes $WORKER_IP2 \
     --file configs/worker.yaml \
     --config-patch @patches/worker-02.yaml \
+    --config-patch @patches/worker-data-disk.yaml \
     --insecure 
 ```
 

--- a/talos/patches/worker-data-disk.yaml
+++ b/talos/patches/worker-data-disk.yaml
@@ -1,0 +1,31 @@
+# Worker data disk — provisions the spare SATA disk (/dev/sda) as a Longhorn
+# bulk-storage tier. See issue #9.
+#
+# This is a standalone machine-config document (not a strategic-merge patch of
+# machine:/cluster:). Apply it *alongside* the per-worker patch:
+#
+#   talosctl apply-config --nodes $WORKER_IP \
+#     --file configs/worker.yaml \
+#     --config-patch @patches/worker-01.yaml \
+#     --config-patch @patches/worker-data-disk.yaml
+#
+# A UserVolumeConfig is auto-mounted at /var/mnt/<name>, so this volume lands at
+# /var/mnt/hdd — matching the kubelet extraMount already declared in the worker
+# patches. Talos wipes + reformats the selected disk on first apply (the disk is
+# empty, so there is nothing to preserve).
+#
+# Disk is selected by property rather than the unstable /dev/sda name: the spare
+# disk shares the sd* namespace with the iSCSI volumes Longhorn attaches, which
+# report transport "iscsi". The lone physical SATA disk is matched by
+# transport + a size floor. Control-plane is excluded — it has no such disk.
+apiVersion: v1alpha1
+kind: UserVolumeConfig
+name: hdd
+provisioning:
+  diskSelector:
+    match: disk.transport == 'sata' && disk.size > 400u * GB
+  # Consume the whole disk: start at a small floor and grow to fill it.
+  minSize: 100GB
+  grow: true
+filesystem:
+  type: xfs


### PR DESCRIPTION
## Summary

Expands Longhorn capacity by provisioning the spare `/dev/sda` SATA disk on each
worker as a **bulk (HDD) storage tier**, and steers scheduling by disk tag so
general PVCs stay on fast NVMe while opt-in PVCs target the HDD. Closes #9.

Two tiers:

| Tier | Disk | Tag | StorageClass |
| ---- | ---- | --- | ------------ |
| Fast (default) | NVMe `/var/lib/longhorn` | `ssd` | `longhorn` (default) |
| Bulk (opt-in)  | SATA HDD `/var/mnt/hdd` (workers) | `hdd` | `longhorn-hdd` |

## Changes

**Talos**
- `talos/patches/worker-data-disk.yaml`: `UserVolumeConfig` formatting `/dev/sda`
  (xfs) and auto-mounting it at `/var/mnt/hdd`, selected by property
  (`disk.transport == 'sata'` + size floor) rather than the unstable `sda` name.
  Replaces the deprecated `machine.disks` drift.
- `talos/README.md`: worker apply commands include the data-disk patch.

**Longhorn**
- `helmfile.yaml`: chart **1.6.2 → 1.7.2** (the `defaultDiskSelector` value
  only exists from 1.7) + postsync hooks for disk tagging and the HDD class.
- `values.yaml`: pin the default `longhorn` class to the `ssd` tier via
  `persistence.defaultDiskSelector`.
- `resources/disks.sh`: idempotent `nodes.longhorn.io` patches — tag each node's
  NVMe disk `ssd` (matched by path) and register `/var/mnt/hdd` as the `hdd`
  disk on workers. Requires `jq`.
- `resources/storageclass-hdd.yaml`: opt-in `longhorn-hdd` class
  (`diskSelector: hdd`).
- `README.md`: documents the tiers and the chart-version caveat.

**Docs**
- `CLAUDE.md`: storage-tier architecture decision + the worker `/var/mnt/hdd` mount.

## Rollout status (already applied to the live cluster)

- ✅ `UserVolumeConfig` provisioned `/dev/sda` → `/var/mnt/hdd` on both workers
  (legacy `machine.disks` retired; disk wiped + reprovisioned).
- ✅ Longhorn upgraded to 1.7.2; NVMe tagged `ssd`, HDD registered + tagged `hdd`,
  both `Ready`/`Schedulable`.
- ✅ Default `longhorn` class has `diskSelector: ssd`; `longhorn-hdd` created.
- ✅ End-to-end: a `longhorn-hdd` PVC bound and its replica landed on
  `/var/mnt/hdd`.

> Note: `disks.sh` required a fix during rollout — Longhorn stores the default
> disk path with a trailing slash (`/var/lib/longhorn/`), so path matching now
> normalizes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)