### PR TITLE
feat(longhorn): enable replica auto-balance and keep replicas off cp-01

### DIFF
--- a/infrastructure/releases/longhorn/resources/disks.sh
+++ b/infrastructure/releases/longhorn/resources/disks.sh
@@ -87,6 +87,16 @@ function add_hdd_disk() {
     }'
 }
 
+# Keep the control plane out of the Longhorn scheduling pool — volume replicas
+# belong on the workers (cp-01 is tainted and resource-constrained). Existing
+# replicas are not evicted; only new scheduling is disabled. See #49.
+function disable_scheduling() {
+    local node="$1"
+    echo "Disabling Longhorn scheduling on control-plane node '$node'"
+    kubectl -n "$NAMESPACE" patch nodes.longhorn.io "$node" --type=merge \
+        -p '{"spec":{"allowScheduling":false}}'
+}
+
 function main() {
     require_tools
     wait_for_crd
@@ -103,6 +113,12 @@ function main() {
     for node in $(kubectl get nodes -l node-role/worker=true \
         -o jsonpath='{.items[*].metadata.name}'); do
         add_hdd_disk "$node"
+    done
+
+    # Keep replicas off the control plane (workers carry the storage). See #49.
+    for node in $(kubectl get nodes -l node-role.kubernetes.io/control-plane \
+        -o jsonpath='{.items[*].metadata.name}'); do
+        disable_scheduling "$node"
     done
 }
 

--- a/infrastructure/releases/longhorn/values.yaml
+++ b/infrastructure/releases/longhorn/values.yaml
@@ -5,6 +5,14 @@ metrics:
 
 defaultSettings:
   defaultReplicaCount: 1
+  # Replica Auto Balance spreads a volume's OWN replicas across nodes. It is a
+  # no-op while defaultReplicaCount is 1 (a single replica can't be spread) —
+  # enabled here so that multi-replica volumes self-balance going forward. It
+  # does NOT redistribute different single-replica volumes to even out node load
+  # (that needs a manual move or a higher replica count). Control-plane
+  # scheduling is disabled in resources/disks.sh, so balancing stays on the
+  # workers. See #49.
+  replicaAutoBalance: best-effort
   storageReservedPercentageForDefaultDisk: 30
   # Thin-provisioning headroom. Longhorn schedules by a volume's *requested*
   # size, not actual usage; the default 100 lets total requested replica size


### PR DESCRIPTION
## Summary

Enables Longhorn **Replica Auto Balance** (`best-effort`) and removes the
control plane from the Longhorn scheduling pool so replicas stay on the workers.
Refs #49.

## Changes

- `releases/longhorn/values.yaml`: `defaultSettings.replicaAutoBalance: best-effort`
- `releases/longhorn/resources/disks.sh`: set `allowScheduling: false` on the
  control-plane Longhorn node (workers-only storage — consistent with
  `allowSchedulingOnControlPlanes: false` and the #28 cp-01 eviction history)

## ⚠️ Key finding — and why existing volumes are not rebalanced

`replica-auto-balance` spreads **a single volume's own replicas** across nodes.
With `defaultReplicaCount: 1` there is nothing to spread, so it is a **no-op for
the current single-replica volumes** — it does **not** redistribute different
volumes to even out per-node load. All 7 volumes therefore remain on
`talos-worker-01` for now.

The setting is still enabled because it makes **multi-replica** volumes
self-balance going forward, and excluding cp-01 is correct regardless.

**Decision (per issue #49):** config-only — defer actually moving the existing
volumes. To rebalance them later, either raise the replica count to 2 (balanced
+ redundant, ~2x storage) or manually move ~half while keeping count 1.

## Applied + verified on the cluster

- `replica-auto-balance` = `best-effort` (live, rev 12)
- `talos-cp-01` node `allowScheduling: false`; workers `true`
- `disks.sh` re-ran cleanly (the trailing-slash fix holds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)