### PR TITLE
feat(langfuse): deploy LLM observability stack under apps/ai

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ talos/configs/
 # Sensitive Helm release resources — apply manually before helmfile sync
 infrastructure/releases/*/resources/secret.yaml
 apps/observability/releases/*/resources/secret.yaml
+apps/ai/releases/*/resources/secret.yaml
 # Personal, machine-local Claude Code settings
 .claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,16 +30,20 @@ k8s-homelab/
 │       ├── longhorn/        # Distributed block storage (namespace: longhorn-system); tiered ssd/hdd disks
 │       └── metrics-server/  # Backs metrics.k8s.io API (kubectl top / HPA)
 └── apps/                   # Application-layer Helm releases (run on top of the cluster)
-    └── observability/       # Observability stack (namespace: monitoring)
-        ├── helmfile.yaml    # Aggregating helmfile — includes the four releases below
-        └── releases/        # One sub-helmfile per release
-            ├── prometheus/  # kube-prometheus-stack
-            ├── loki/        # Log aggregation
-            ├── grafana/     # Dashboards
-            └── alloy/       # Grafana Alloy log/metrics collector
+    ├── observability/       # Observability stack (namespace: monitoring)
+    │   ├── helmfile.yaml    # Aggregating helmfile — includes the four releases below
+    │   └── releases/        # One sub-helmfile per release
+    │       ├── prometheus/  # kube-prometheus-stack
+    │       ├── loki/        # Log aggregation
+    │       ├── grafana/     # Dashboards
+    │       └── alloy/       # Grafana Alloy log/metrics collector
+    └── ai/                  # AI/LLM stack (namespace: langfuse)
+        ├── helmfile.yaml    # Aggregating helmfile — includes the release(s) below
+        └── releases/
+            └── langfuse/    # LLM observability / tracing (postgresql + clickhouse + valkey + minio bundled, single-replica)
 ```
 
-> The observability releases under `apps/observability/` are aggregated by `apps/observability/helmfile.yaml` and applied as a unit — they are **not** wired into the root `infrastructure/helmfile.yaml`.
+> The releases under `apps/observability/` and `apps/ai/` are each aggregated by their own `helmfile.yaml` and applied as a unit — they are **not** wired into the root `infrastructure/helmfile.yaml`.
 
 ## Common Commands
 
@@ -61,6 +65,9 @@ cd apps/observability && helmfile apply
 # Deploy a single observability release
 cd apps/observability && helmfile -l name=prometheus apply
 cd apps/observability && helmfile -f releases/loki/helmfile.yaml apply
+
+# Deploy the AI stack (Langfuse + bundled backing stores)
+cd apps/ai && helmfile -f releases/langfuse/helmfile.yaml apply
 ```
 
 ### Talos Operations

--- a/apps/ai/helmfile.yaml
+++ b/apps/ai/helmfile.yaml
@@ -1,0 +1,13 @@
+helmDefaults:
+  # when using helm 3.2+, automatically create release namespaces if they do not exist (default true)
+  createNamespace: true
+  # performs pods restart for the resource if applicable (default false)
+  recreatePods: true
+  # wait for k8s resources via --wait. (default false)
+  wait: true
+  # langfuse brings up four backing stores (postgresql, clickhouse + zookeeper,
+  # valkey, minio) plus migrations on first sync — give it room before --wait gives up
+  timeout: 900
+
+helmfiles:
+  - path: releases/langfuse/helmfile.yaml # langfuse: LLM observability / tracing

--- a/apps/ai/releases/langfuse/README.md
+++ b/apps/ai/releases/langfuse/README.md
@@ -1,0 +1,67 @@
+# Langfuse
+
+[Langfuse](https://langfuse.com/) — open-source LLM observability / tracing — deployed
+via the `langfuse/langfuse` Helm chart (v1.5.33, app 3.177.0).
+
+Langfuse v3 is not a single container; it brings four bundled backing stores, all run
+single-replica here and slimmed down from the chart's production HA defaults
+(`clickhouse` alone defaults to 3 replicas / `2xlarge` ≈ 7 CPU / 20Gi):
+
+| Component | Purpose | Workload |
+|---|---|---|
+| PostgreSQL | transactional / config data | `langfuse-postgresql` |
+| ClickHouse | traces/observations OLAP store | `langfuse-clickhouse` |
+| Valkey (Redis) | queue + cache | `langfuse-redis` |
+| MinIO (S3) | event & media blob storage | `langfuse-s3` |
+| langfuse web/worker | app + async worker | `langfuse-web`, `langfuse-worker` |
+
+ClickHouse runs as a single node, so the chart sets `CLICKHOUSE_CLUSTER_ENABLED=false`
+(non-replicated tables) and the bundled Zookeeper is disabled — no coordinator needed.
+
+All PVCs land on `longhorn` via `global.defaultStorageClass`. Ingress is
+`nginx-internal` at `http://langfuse.home`; external-dns syncs the host to Pi-hole.
+
+## Secrets
+
+`resources/secret.yaml` is **gitignored** (`apps/ai/releases/*/resources/secret.yaml`) and
+merged on top of `values.yaml` by `helmfile.yaml`. It holds `salt`, `nextauth.secret`,
+`encryptionKey`, and the postgresql/clickhouse/redis/s3 passwords. Regenerate with:
+
+```bash
+openssl rand -base64 32   # salt, nextauth.secret
+openssl rand -hex 32      # encryptionKey (must be 64 hex chars)
+openssl rand -hex 16      # store passwords (hex avoids URL-encoding issues)
+```
+
+## Deploy
+
+Applied directly (like the observability stack), **not** wired into the root
+`infrastructure/helmfile.yaml`:
+
+```bash
+cd apps/ai && helmfile -f releases/langfuse/helmfile.yaml apply
+# or the whole apps/ai aggregate:
+cd apps/ai && helmfile apply
+```
+
+First sync runs PostgreSQL + ClickHouse migrations and can take several minutes
+(the helmfile `timeout` is raised to 900s for this reason).
+
+## Verify
+
+```bash
+kubectl get pods -n langfuse                       # all Ready
+kubectl get ingress -n langfuse                    # host langfuse.home
+kubectl logs -n langfuse deploy/langfuse-web       # migrations / startup
+```
+
+Browse to `http://langfuse.home`, create the first account (sign-up is open).
+Consider setting `langfuse.features.signUpDisabled: true` afterwards to lock it down.
+
+## PodSecurity note
+
+The cluster enforces PodSecurity admission with only the `infra` namespace exempted
+(`talos/patches/cp-01.yaml`). The langfuse app pods are hardened (non-root, drop ALL,
+`RuntimeDefault` seccomp). If the Bitnami store pods (ClickHouse/MinIO/PostgreSQL/Valkey)
+are rejected at admission, add `langfuse` to the PodSecurity `exemptions.namespaces` list
+in `talos/patches/cp-01.yaml` and re-apply the control-plane config.

--- a/apps/ai/releases/langfuse/helmfile.yaml
+++ b/apps/ai/releases/langfuse/helmfile.yaml
@@ -1,0 +1,13 @@
+repositories:
+  - name: langfuse
+    url: https://langfuse.github.io/langfuse-k8s
+
+releases:
+  - name: langfuse
+    namespace: langfuse
+    chart: langfuse/langfuse
+    version: 1.5.33 # app 3.177.0
+    values:
+      - values.yaml
+      # secrets file is gitignored — salt/nextauth/encryptionKey + store passwords in resources/secret.yaml
+      - resources/secret.yaml

--- a/apps/ai/releases/langfuse/values.yaml
+++ b/apps/ai/releases/langfuse/values.yaml
@@ -1,0 +1,155 @@
+global:
+  # All backing-store PVCs (postgresql, clickhouse, valkey, minio) are Bitnami
+  # subcharts and honour this global — keeps every volume on Longhorn.
+  defaultStorageClass: longhorn
+  security:
+    # The bundled stores default to bitnamilegacy/* images (Bitnami moved the
+    # free tier there); this flag is required for the chart to accept them.
+    allowInsecureImages: true
+
+# Core Langfuse Configuration (web + worker deployments)
+langfuse:
+  features:
+    # Homelab privacy stance — matches grafana (analytics/reporting disabled).
+    telemetryEnabled: false
+    # Leave sign-up open so the first admin account can be created, then flip to
+    # true after onboarding to lock the instance down.
+    signUpDisabled: false
+
+  # salt / nextauth.secret / encryptionKey are supplied via the gitignored
+  # resources/secret.yaml (merged on top of this file by helmfile.yaml).
+
+  nextauth:
+    # Must be the canonical externally-reachable URL (the ingress host below).
+    url: http://langfuse.home
+
+  ingress:
+    enabled: true
+    className: nginx-internal
+    hosts:
+      - host: langfuse.home
+        paths:
+          - path: /
+            pathType: Prefix
+
+  # Keep langfuse pods on worker nodes (control-plane is tainted NoSchedule, but
+  # this is explicit and mirrors the grafana release).
+  nodeSelector:
+    node-role/worker: "true"
+
+  # Run non-root and drop capabilities so the pods satisfy PodSecurity.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+  securityContext:
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+
+  web:
+    # langfuse-web is a Next.js SSR app. Node sizes its V8 heap to ~half the
+    # container memory limit, so a 1Gi limit caps the heap at ~512Mi and the pod
+    # aborts with "heap out of memory" (exit 134) during init. Give it 2Gi and
+    # pin the heap explicitly so it can grow without relying on cgroup detection.
+    pod:
+      additionalEnv:
+        - name: NODE_OPTIONS
+          value: "--max-old-space-size=1536"
+    resources:
+      requests:
+        cpu: 100m
+        memory: 1Gi
+      limits:
+        cpu: "1"
+        memory: 2Gi
+
+  worker:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 512Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi
+
+# PostgreSQL — transactional / config data (Bitnami subchart)
+postgresql:
+  deploy: true
+  # auth.password comes from resources/secret.yaml
+  primary:
+    persistence:
+      enabled: true
+      size: 8Gi
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+# Valkey / Redis — queue + cache (Bitnami subchart)
+redis:
+  deploy: true
+  # auth.password comes from resources/secret.yaml
+  primary:
+    # Required by langfuse — the queue must never evict keys.
+    extraFlags:
+      - "--maxmemory-policy noeviction"
+    persistence:
+      enabled: true
+      size: 4Gi
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 300m
+        memory: 256Mi
+
+# ClickHouse — traces/observations OLAP store (Bitnami subchart)
+# Chart defaults are production HA sizing (replicaCount 3, resourcesPreset
+# 2xlarge ≈ 7 CPU / 20Gi). Slim to a single node for the homelab.
+clickhouse:
+  deploy: true
+  replicaCount: 1
+  resourcesPreset: none # disable the 2xlarge preset; explicit resources below win
+  # auth.password comes from resources/secret.yaml
+  resources:
+    requests:
+      cpu: 250m
+      memory: 1Gi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+  persistence:
+    enabled: true
+    size: 20Gi
+  # With replicaCount 1 the chart sets CLICKHOUSE_CLUSTER_ENABLED=false, so langfuse
+  # uses non-replicated MergeTree tables and needs no coordinator — drop the bundled
+  # Zookeeper (default is a 3-node ensemble) entirely.
+  zookeeper:
+    enabled: false
+
+# MinIO — event & media blob storage (Bitnami subchart)
+s3:
+  deploy: true
+  defaultBuckets: langfuse
+  # auth.rootPassword comes from resources/secret.yaml
+  mode: standalone
+  persistence:
+    enabled: true
+    size: 20Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi


### PR DESCRIPTION
Closes #23.

Deploys [Langfuse](https://langfuse.com/) v3 (chart `langfuse/langfuse` **1.5.33**, app **3.177.0**) following the per-release Helmfile + GitOps conventions. Adapted to live under `apps/ai/` (mirroring `apps/observability/`) rather than the issue's pre-refactor `infrastructure/releases/` path.

## What's included
- **`apps/ai/helmfile.yaml`** — aggregating helmfile for the AI stack; `timeout` raised to 900s for first-sync migrations. Applied directly (not wired into the root `infrastructure/helmfile.yaml`).
- **`apps/ai/releases/langfuse/`** — release `helmfile.yaml` (pinned to chart 1.5.33), `values.yaml`, and a `README.md`.
- **`.gitignore`** — ignore `apps/ai/releases/*/resources/secret.yaml`.
- **`CLAUDE.md`** — `apps/ai/` added to the repo-structure tree and deploy commands.

## Configuration highlights
- All four backing stores bundled **single-replica**, slimmed from the vendor's production HA sizing (~7 CPU / 20Gi):
  - ClickHouse: `replicaCount 3 → 1`, `2xlarge` preset → explicit small resources. Single node disables `CLICKHOUSE_CLUSTER_ENABLED`, so the bundled **Zookeeper is dropped** (non-replicated tables, no coordinator needed).
  - PostgreSQL / Valkey / MinIO: single-replica with slimmed resources.
- Storage: all PVCs on `longhorn` via `global.defaultStorageClass`.
- Ingress: `nginx-internal`, host `langfuse.home` (external-dns → Pi-hole).
- Secrets: `salt` / `nextauth.secret` / `encryptionKey` + store passwords live in a **gitignored** `resources/secret.yaml`, merged on top of `values.yaml` (matches the grafana/loki pattern). Nothing sensitive committed.
- Hardened langfuse pods (non-root, drop ALL caps, `RuntimeDefault` seccomp).

## Validation
Deployed to the cluster (release rev 2) and verified healthy:
- All 6 workloads `Running` / Ready, 0 restarts.
- App health via ingress: `{"status":"OK","version":"3.177.0"}` (HTTP 200); `/api/public/ready` 200.
- `langfuse.home` resolves to the L2 ingress IP `192.168.1.200`.
- PVCs bound on `longhorn`; no Zookeeper pod.

During validation `langfuse-web` initially crash-looped with a Node heap OOM (exit 134) — the original `1Gi` web limit capped the V8 heap at ~512Mi. Fixed by raising the web tier to `2Gi` and pinning `NODE_OPTIONS=--max-old-space-size=1536`.

## Notes
- PodSecurity exemption was **not** needed — the Bitnami store pods admitted fine under the default policy; `talos/patches/cp-01.yaml` is untouched.
- The gitignored `secret.yaml` exists only locally; a fresh clone/cluster must regenerate it (commands in the release README) before `helmfile apply`.