### PR TITLE
fix(external-dns): switch to Pi-hole provider on kubernetes-sigs chart

### DIFF
--- a/infrastructure/releases/external-dns/helmfile.yaml
+++ b/infrastructure/releases/external-dns/helmfile.yaml
@@ -1,11 +1,11 @@
 repositories:
-  - name: bitnami
-    url: https://charts.bitnami.com/bitnami
+  - name: kubernetes-sigs
+    url: https://kubernetes-sigs.github.io/external-dns/
 
 releases:
-  - name: externaldns-unifi
+  - name: externaldns
     namespace: infra
-    chart: bitnami/external-dns
-    version: 9.0.3
+    chart: kubernetes-sigs/external-dns
+    version: 1.20.0
     values:
       - values.yaml

--- a/infrastructure/releases/external-dns/values.yaml
+++ b/infrastructure/releases/external-dns/values.yaml
@@ -1,58 +1,28 @@
-global:
-  security:
-    allowInsecureImages: true
+provider:
+  name: pihole
 
-image:
-  registry: registry.k8s.io
-  repository: external-dns/external-dns
-  tag: v0.18.0
-
-provider: webhook
+registry: noop
 policy: upsert-only
-txtOwnerId: "homelab"
 
-extraArgs:
-  webhook-provider-url: http://localhost:8888
-
-sidecars:
-  - name: unifi-webhook
-    image: ghcr.io/kashalls/external-dns-unifi-webhook:v0.4.2
-    imagePullPolicy: IfNotPresent
-    ports:
-      - name: http
-        containerPort: 8888
-      - name: metrics
-        containerPort: 8080
-    livenessProbe:
-      httpGet:
-        path: /healthz
-        port: metrics
-      initialDelaySeconds: 10
-      timeoutSeconds: 5
-    readinessProbe:
-      httpGet:
-        path: /readyz
-        port: metrics
-      initialDelaySeconds: 10
-      timeoutSeconds: 5
-    env:
-      - name: UNIFI_HOST
-        value: "https://192.168.1.1"
-      - name: UNIFI_API_KEY
-        valueFrom:
-          secretKeyRef:
-            name: external-dns-unifi-secret
-            key: api-key
-      - name: UNIFI_INSECURE
-        value: "true"
-
-serviceAccount:
-  create: true
-  name: "external-dns-unifi"
-# Watch Gateway API HTTPRoutes and plain Services (Ingress source removed with nginx).
 sources:
   - service
   - gateway-httproute
+
+extraArgs:
+  pihole-server: http://pihole-web.infra.svc.cluster.local
+  pihole-api-version: "6"
+
+env:
+  - name: EXTERNAL_DNS_PIHOLE_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: pihole-password
+        key: password
+
+serviceAccount:
+  create: true
+  name: external-dns
+
 resources:
   requests:
     cpu: 100m


### PR DESCRIPTION
Closes #12

## Summary

- Replaces the stale Unifi-webhook config with the native Pi-hole provider
- Adopts the `externaldns` release name (matching what's already live) so `helmfile apply` upgrades in-place rather than creating a duplicate orphaned release
- Adds `--pihole-api-version=6` to target Pi-hole's v6 REST API (cluster is on Pi-hole v6.4.2; default is v5, which 404s)

## Changes

| File | What changed |
|------|-------------|
| `helmfile.yaml` | Swap bitnami → kubernetes-sigs chart (1.20.0); release `externaldns-unifi` → `externaldns` |
| `values.yaml` | Rewrite: Pi-hole provider, `gateway-httproute` source, Pi-hole v6 API flag, password from secret; remove Unifi sidecar |

## Test plan

- [x] `helmfile diff` showed only expected ClusterRole (ingress→gateway RBAC) and Deployment (source/arg) changes
- [x] `helmfile apply` upgraded in-place (revision 2→3), no orphaned releases
- [x] Pod rolled out with 0 restarts
- [x] Logs confirm sync: `PUT langfuse.home IN A → 192.168.1.200`, `PUT grafana.home IN A → 192.168.1.200`, etc.